### PR TITLE
feat: add async has,get,set methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ This module have the following API:
 
 Constructor takes no arguments.
 
+
+### get(fileName: string): Promise<string>
+
+Async method for reading a file from storage
+
+### set(fileName: string, fileContent: string): Promise<void>
+
+Async method for writing file to storage
+
+### has(fileName: string): Promise<Boolean>
+
+Async method for checking if file exist in storage
+
+
 ### writer(type)
 
 Method for writing a file to memory. Returns a write stream.

--- a/lib/sink.js
+++ b/lib/sink.js
@@ -66,6 +66,24 @@ module.exports = class SinkMem extends EventEmitter {
         this.db = {};
     }
 
+    async get(fileName) {
+        if (this.db[fileName]) {
+            return this.db[fileName];
+        }
+        throw new Error(`No file with ${fileName}`);
+    }
+
+    async set(fileName, fileContent) {
+        assert(fileName, '"filename" is missing');
+        assert(fileContent, '"fileContent" is missing');
+        this.db[fileName] = fileContent;
+    }
+
+    async has(fileName) {
+        assert(fileName, '"filename" is missing');
+        return !!this.db[fileName];
+    }
+
     writer(type) {
         assert(type, '"type" is missing');
         return new WriteStream(this.db, type);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "Richard Walker (https://github.com/digitalsadhu)",
     "Sveinung Røsaker (https://github.com/sveisvei)"
   ],
+  "engines": {
+    "node": ">=8"
+  },
   "bugs": {
     "url": "https://github.com/asset-pipe/asset-pipe-sink-mem/issues"
   },

--- a/test/__snapshots__/sink.test.js.snap
+++ b/test/__snapshots__/sink.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.set() - should not set value if missing value 1`] = `[AssertionError [ERR_ASSERTION]: "fileContent" is missing]`;
+
+exports[`.set() - should not set value if missing value 2`] = `[Error: No file with some-key-1]`;

--- a/test/sink.test.js
+++ b/test/sink.test.js
@@ -4,10 +4,55 @@ const stream = require('readable-stream');
 const Sink = require('../');
 const fs = require('fs');
 
+test('.get() - non value should error', async () => {
+    const sink = new Sink();
+
+    expect(sink.get('some-key')).rejects.toEqual(
+        new Error('No file with some-key')
+    );
+});
+
+test('.set() - should set value', async () => {
+    const sink = new Sink();
+
+    await sink.set('some-key-1', 'value-1');
+    expect(await sink.get('some-key-1')).toBe('value-1');
+});
+
+test('.set() - should not set value if missing value', async () => {
+    expect.assertions(2);
+    const sink = new Sink();
+
+    try {
+        await sink.set('some-key-1');
+    } catch (e) {
+        expect(e).toMatchSnapshot();
+    }
+
+    try {
+        await sink.get('some-key-1');
+    } catch (e) {
+        expect(e).toMatchSnapshot();
+    }
+});
+
+test('.has() - should return false if value not present', async () => {
+    const sink = new Sink();
+
+    expect(await sink.has('some-key-1')).toBe(false);
+});
+
+test('.has() - should return true if value present', async () => {
+    const sink = new Sink();
+
+    await sink.set('some-key-1', 'value-1');
+    expect(await sink.has('some-key-1')).toBe(true);
+});
+
 test('.writer() - no value for "type" argument - should throw', () => {
     const sink = new Sink();
     expect(() => {
-        const dest = sink.writer(); // eslint-disable-line
+        sink.writer();
     }).toThrowError('"type" is missing');
 });
 
@@ -36,7 +81,7 @@ test('.writer() - on "file saved" - should have "id" and "file" on emitted event
 test('.reader() - no value for "file" argument - should throw', () => {
     const sink = new Sink();
     expect(() => {
-        const source = sink.reader(); // eslint-disable-line
+        sink.reader();
     }).toThrowError('"file" is missing');
 });
 


### PR DESCRIPTION
## JIRA Issue
[COREWEB-39](https://jira.finn.no/browse/COREWEB-39)

## Status
**READY**

## Description
Adds async methods to support setting and gettings files without streams, needed for simpler meta-data storage interface.

## Todos
- [x] Tests
- [x] Documentation

## Related PRs
* https://github.com/asset-pipe/asset-pipe-sink-gcs/pull/46