### PR TITLE
feat: add directory method

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ Async method for writing file to storage
 
 Async method for checking if file exist in storage
 
+### dir(directoryName: string): Promise<Array>
+
+Async method for getting all files in a given directory
 
 ### writer(type)
 

--- a/lib/sink.js
+++ b/lib/sink.js
@@ -6,6 +6,7 @@ const common = require('asset-pipe-common');
 const stream = require('readable-stream');
 const concat = require('concat-stream');
 const assert = require('assert');
+const path = require('path');
 
 class WriteStream extends stream.PassThrough {
     constructor(db, type) {
@@ -82,6 +83,24 @@ module.exports = class SinkMem extends EventEmitter {
     async has(fileName) {
         assert(fileName, '"filename" is missing');
         return !!this.db[fileName];
+    }
+
+    async dir(directoryName) {
+        const results = Object.keys(this.db)
+            .filter(key => {
+                const dirname = `/${path.dirname(key)}`.replace(/\.$/, '');
+                return dirname === directoryName;
+            })
+            .map(key => ({
+                fileName: key,
+                content: this.db[key],
+            }));
+        if (results.length === 0) {
+            throw new Error(
+                `Missing folder with name "${directoryName}" or empty result`
+            );
+        }
+        return results;
     }
 
     writer(type) {

--- a/test/__snapshots__/sink.test.js.snap
+++ b/test/__snapshots__/sink.test.js.snap
@@ -3,3 +3,48 @@
 exports[`.set() - should not set value if missing value 1`] = `[AssertionError [ERR_ASSERTION]: "fileContent" is missing]`;
 
 exports[`.set() - should not set value if missing value 2`] = `[Error: No file with name "some-key-1"]`;
+
+exports[`dir() - should error when folder does not exist 1`] = `"Missing folder with name \\"/dir/missing\\" or empty result"`;
+
+exports[`dir() - should list 1 file from a directory 1`] = `
+Array [
+  Object {
+    "content": "value-1",
+    "fileName": "some-key-1",
+  },
+]
+`;
+
+exports[`dir() - should list 3 files from a directory 1`] = `
+Array [
+  Object {
+    "content": "value-1",
+    "fileName": "some-key-1",
+  },
+  Object {
+    "content": "value-1",
+    "fileName": "some-key-2",
+  },
+  Object {
+    "content": "value-1",
+    "fileName": "some-key-3",
+  },
+]
+`;
+
+exports[`dir() - should list 3 files from a sub directory 1`] = `
+Array [
+  Object {
+    "content": "wanted-1",
+    "fileName": "dir/sub/some-key-1",
+  },
+  Object {
+    "content": "wanted-2",
+    "fileName": "dir/sub/some-key-2",
+  },
+  Object {
+    "content": "wanted-3",
+    "fileName": "dir/sub/some-key-3",
+  },
+]
+`;

--- a/test/sink.test.js
+++ b/test/sink.test.js
@@ -49,6 +49,49 @@ test('.has() - should return true if value present', async () => {
     expect(await sink.has('some-key-1')).toBe(true);
 });
 
+test('dir() - should list 1 file from a directory', async () => {
+    const sink = new Sink();
+
+    await sink.set('some-key-1', 'value-1');
+    expect(await sink.dir('/')).toMatchSnapshot();
+});
+
+test('dir() - should list 3 files from a directory', async () => {
+    const sink = new Sink();
+
+    await sink.set('some-key-1', 'value-1');
+    await sink.set('some-key-2', 'value-1');
+    await sink.set('some-key-3', 'value-1');
+    expect(await sink.dir('/')).toMatchSnapshot();
+});
+
+test('dir() - should list 3 files from a sub directory', async () => {
+    const sink = new Sink();
+
+    await sink.set('some-key-1', 'value-1');
+    await sink.set('some-key-2', 'value-1');
+    await sink.set('another/some-key-3', 'value-1');
+    await sink.set('dir/sub/some-key-1', 'wanted-1');
+    await sink.set('dir/sub/some-key-2', 'wanted-2');
+    await sink.set('dir/sub/some-key-3', 'wanted-3');
+    expect(await sink.dir('/dir/sub')).toMatchSnapshot();
+});
+
+test('dir() - should error when folder does not exist', async () => {
+    expect.assertions(1);
+    const sink = new Sink();
+
+    await sink.set('some-key-1', 'value-1');
+    await sink.set('some-key-2', 'value-1');
+    await sink.set('another/some-key-3', 'value-1');
+    await sink.set('dir/sub/some-key-1', 'wanted-1');
+    try {
+        await sink.dir('/dir/missing');
+    } catch (e) {
+        expect(e.message).toMatchSnapshot();
+    }
+});
+
 test('.writer() - no value for "type" argument - should throw', () => {
     const sink = new Sink();
     expect(() => {


### PR DESCRIPTION
## JIRA Issue
[COREWEB-83](https://jira.finn.no/browse/COREWEB-83)

## Status
**READY**

## Description
Add a new async method for listing files in a directory.

It returns an array with objects of shape: `{fileName, content}`

## Todos
- [x] Tests
- [x] Documentation

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work. These should note any
db migrations, etc. -->

## Related PRs
* https://github.com/asset-pipe/asset-pipe-sink-fs/pull/40
* https://github.com/asset-pipe/asset-pipe-sink-gcs/pull/50